### PR TITLE
Closes #4 fix for other localizations parse exception 

### DIFF
--- a/Pingprovements/Extensions.cs
+++ b/Pingprovements/Extensions.cs
@@ -20,7 +20,8 @@ namespace Pingprovements
         
         public static Color ToColor(this string colorString)
         {
-            float[] colorValues = Array.ConvertAll(colorString.Split(','), float.Parse);
+            float[] colorValues = Array.ConvertAll(colorString.Split(','), 
+                                                  str => float.Parse(str, System.Globalization.CultureInfo.InvariantCulture));
 
             return new Color(colorValues[0], colorValues[1], colorValues[2], colorValues[3]);
         }


### PR DESCRIPTION
This pull request fixes #4 by using a fixed localization, so it's not affected by different systems that may have a different one that doesn't allow them to parse a float number divided by a "." decimal point correctly.

Should still work on all systems, but I only tested on a Portuguese one.